### PR TITLE
修复未加载 vendor 导致运行失败

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -24,6 +24,10 @@ const manifest: Manifest.WebExtensionManifest = {
     },
     content_scripts: [
         {
+            matches: ['<all_urls>'],
+            js: [...(__DEV__ ? [] : ['js/vendor.js'])],
+        },
+        {
             matches: ['https://github.com/*'],
             css: ['css/all.css'],
             js: ['js/all.js', ...(__DEV__ ? [] : ['js/all.js'])],

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -24,10 +24,6 @@ const manifest: Manifest.WebExtensionManifest = {
     },
     content_scripts: [
         {
-            matches: ['<all_urls>'],
-            js: [...(__DEV__ ? [] : ['js/vendor.js'])],
-        },
-        {
             matches: ['https://github.com/*'],
             css: ['css/all.css'],
             js: ['js/all.js', ...(__DEV__ ? [] : ['js/all.js'])],
@@ -53,5 +49,11 @@ const manifest: Manifest.WebExtensionManifest = {
         '128': 'icons/extension-icon-x128.png',
     },
 };
+if (!__DEV__) {
+    manifest.content_scripts?.unshift({
+        matches: ['<all_urls>'],
+        js: ['js/vendor.js'],
+    });
+}
 
 export default manifest;


### PR DESCRIPTION
webpack build 的时候会生成 vendor.js 文件，如果不把 vendor.js 
 文件添加到 content-script 中会导致，模块未加载，运行失败。